### PR TITLE
Background steps, radioSilence, sending messages on .utility

### DIFF
--- a/CCLocation.podspec
+++ b/CCLocation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'CCLocation'
-  s.version               = '2.5.1'
+  s.version               = '2.5.2'
   s.summary               = 'The CrowdConnected colocator iOS library'
   s.homepage              = 'https://github.com/crowdconnected/colocator-ios.git'
   s.social_media_url      = 'https://twitter.com/crowdconnected'

--- a/CCLocation/CCLocation.swift
+++ b/CCLocation/CCLocation.swift
@@ -45,7 +45,7 @@ internal struct Constants {
         if libraryStarted == false {
             libraryStarted = true
             
-            setLoggerLevels(verbose: false, info: true, debug: true, warning: true, error: true, severe: true)
+            setLoggerLevels(verbose: false, info: false, debug: false, warning: true, error: true, severe: true)
             
             NSLog("[Colocator] Initialising Colocator")
             

--- a/CCLocation/CCLocation.swift
+++ b/CCLocation/CCLocation.swift
@@ -45,7 +45,7 @@ internal struct Constants {
         if libraryStarted == false {
             libraryStarted = true
             
-            setLoggerLevels(verbose: false, info: false, debug: false, warning: false, error: true, severe: true)
+            setLoggerLevels(verbose: false, info: true, debug: true, warning: true, error: true, severe: true)
             
             NSLog("[Colocator] Initialising Colocator")
             
@@ -76,6 +76,8 @@ internal struct Constants {
         if libraryStarted == true {
             libraryStarted = false
             stateStore = nil
+            
+            NSLog("[Colocator] Stopping Colocator")
             
             colocatorManager?.stop()
             colocatorManager = nil

--- a/CCLocation/CCLocation.swift
+++ b/CCLocation/CCLocation.swift
@@ -43,7 +43,7 @@ internal struct Constants {
         if libraryStarted == false {
             libraryStarted = true
             
-            setLoggerLevels(verbose: false, info: false, debug: false, warning: false, error: true, severe: false)
+            setLoggerLevels(verbose: true, info: true, debug: true, warning: true, error: true, severe: true)
             
             NSLog("[Colocator] Initialising Colocator")
             
@@ -169,10 +169,18 @@ internal struct Constants {
                 let clientStatus = jsonResponse?["connect"] as? Bool
                 
                 if clientStatus == true {
-                    self.start(apiKey: key)
-                    Log.info("[Colocator] Library started from background")
-                    completion(true)
-                    return
+                    if self.libraryStarted == true {
+                        self.stop()
+                        self.start(apiKey: key)
+                        Log.info("[Colocator] Library started from background")
+                        completion(true)
+                        return
+                    } else {
+                        self.start(apiKey: key)
+                        Log.info("[Colocator] Library started from background")
+                        completion(true)
+                        return
+                    }
                 }
                 if clientStatus == false {
                     self.stop()

--- a/CCLocation/CCLocation.swift
+++ b/CCLocation/CCLocation.swift
@@ -45,7 +45,7 @@ internal struct Constants {
         if libraryStarted == false {
             libraryStarted = true
             
-            setLoggerLevels(verbose: false, info: false, debug: false, warning: true, error: true, severe: true)
+            setLoggerLevels(verbose: false, info: false, debug: false, warning: false, error: true, severe: true)
             
             NSLog("[Colocator] Initialising Colocator")
             

--- a/CCLocation/CCLocation.swift
+++ b/CCLocation/CCLocation.swift
@@ -45,7 +45,7 @@ internal struct Constants {
         if libraryStarted == false {
             libraryStarted = true
             
-            setLoggerLevels(verbose: true, info: true, debug: true, warning: true, error: true, severe: true)
+            setLoggerLevels(verbose: false, info: false, debug: false, warning: true, error: true, severe: true)
             
             NSLog("[Colocator] Initialising Colocator")
             

--- a/CCLocation/CCLocation.swift
+++ b/CCLocation/CCLocation.swift
@@ -11,6 +11,8 @@ import ReSwift
 import CoreBluetooth
 import CoreLocation
 import CoreMotion
+import UserNotifications
+import UIKit
 
 internal struct Constants {
     static let kDefaultEndPointPartialUrl = ".colocator.net:443/socket"

--- a/CCLocation/CCLocation.swift
+++ b/CCLocation/CCLocation.swift
@@ -45,7 +45,7 @@ internal struct Constants {
         if libraryStarted == false {
             libraryStarted = true
             
-            setLoggerLevels(verbose: false, info: false, debug: false, warning: true, error: true, severe: true)
+            setLoggerLevels(verbose: false, info: true, debug: true, warning: true, error: true, severe: true)
             
             NSLog("[Colocator] Initialising Colocator")
             

--- a/CCLocation/ColocatorManager.swift
+++ b/CCLocation/ColocatorManager.swift
@@ -65,13 +65,13 @@ class ColocatorManager {
             ccSocket = CCSocket.sharedInstance
             ccSocket!.delegate = ccLocation
             
-            ccLocationManager = CCLocationManager(stateStore: state!)
-            ccInertial = CCInertial(stateStore: state!)
-            ccRequestMessaging = CCRequestMessaging(ccSocket: ccSocket!,
-                                                    stateStore: state!)
-            
+            ccLocationManager = CCLocationManager(stateStore: self.state!)
             ccLocationManager!.delegate = self
+            
+            ccInertial = CCInertial(stateStore: self.state!)
             ccInertial!.delegate = self
+
+            ccRequestMessaging = CCRequestMessaging(ccSocket: ccSocket!, stateStore: state!)
             
             Log.info("[Colocator] Attempt to connect to back-end with URL: \(urlString) and APIKey: \(apiKey)")
                        

--- a/CCLocation/Database/SQLiteDatabase.swift
+++ b/CCLocation/Database/SQLiteDatabase.swift
@@ -48,7 +48,7 @@ class SQLiteDatabase {
     
     fileprivate init(dbPointer: OpaquePointer?) {
         self.dbPointer = dbPointer
-        messagesBufferClearTimer = Timer.scheduledTimer(timeInterval: TimeInterval(1000),
+        messagesBufferClearTimer = Timer.scheduledTimer(timeInterval: TimeInterval(1),
                                                         target: self,
                                                         selector: #selector(clearBuffers),
                                                         userInfo: nil,

--- a/CCLocation/Helpers/Constants.swift
+++ b/CCLocation/Helpers/Constants.swift
@@ -23,7 +23,7 @@ struct CCLocationConstants {
 }
 
 struct CCSocketConstants {
-    static let kLibraryVersionToReport = "2.5.1"
+    static let kLibraryVersionToReport = "2.5.2"
     static let kLastDeviceIDKey = "LastDeviceId"
     static let kMinDelay: Double = 1 * 1000
     static let kMaxDelay: Double = 60 * 60 * 1000

--- a/CCLocation/Inertial/CCInertial.swift
+++ b/CCLocation/Inertial/CCInertial.swift
@@ -68,11 +68,14 @@ class CCInertial: NSObject {
             
                startCountingSteps()
                startMotionUpdates()
-            
-                updateFitnessAndMotionStatus()
+               updateFitnessAndMotionStatus()
            } else {
                Log.info("[Colocator] Cannot start inertial due to restricted permission for Motion&Fitness")
-               DispatchQueue.main.async {self.stateStore.dispatch(IsMotionAndFitnessEnabledAction(isMotionAndFitnessEnabled: false))}
+            
+               DispatchQueue.main.async {
+                    if self.stateStore == nil { return }
+                    self.stateStore.dispatch(IsMotionAndFitnessEnabledAction(isMotionAndFitnessEnabled: false))
+               }
            }
        } else {
            Log.info("[Colocator] Starting inertial")
@@ -122,7 +125,9 @@ class CCInertial: NSObject {
                 return
             }
 
-            self?.handleDeviceMotionData(data)
+            DispatchQueue.main.async {
+                self?.handleDeviceMotionData(data)
+            }
         }
     }
     

--- a/CCLocation/Inertial/CCInertial.swift
+++ b/CCLocation/Inertial/CCInertial.swift
@@ -30,13 +30,9 @@ class CCInertial: NSObject {
         queue.maxConcurrentOperationCount = 5
         return queue
     }()
-    
-    var handleDeviceMotionTimer: Timer?
-    
+
     var currentInertialState: InertialState!
-    
     weak var stateStore: Store<LibraryState>!
-    
     public weak var delegate: CCInertialDelegate?
     
     init(stateStore: Store<LibraryState>) {

--- a/CCLocation/Inertial/CCInertial.swift
+++ b/CCLocation/Inertial/CCInertial.swift
@@ -27,6 +27,7 @@ class CCInertial: NSObject {
     private lazy var yawDataOperationQueue: OperationQueue = {
         let queue = OperationQueue()
         queue.name = "Yaw Data queue"
+        queue.maxConcurrentOperationCount = 5
         return queue
     }()
     
@@ -169,7 +170,7 @@ class CCInertial: NSObject {
             if yaw.date.timeIntervalSince1970 < timeInterval {
                 let upperLimit = yawArray.count - index - 1
                 yawDataBuffer.removeSubrange(0 ... upperLimit)
-//                yawDataBuffer.insert(YawData(yaw: yaw.yaw, date: Date(timeIntervalSince1970: yaw.date.timeIntervalSince1970 + 0.019)), at: 0)
+                yawDataBuffer.insert(YawData(yaw: yaw.yaw, date: Date(timeIntervalSince1970: yaw.date.timeIntervalSince1970 + 0.04)), at: 0)
                 return yaw
             }
         }

--- a/CCLocation/Inertial/CCInertial.swift
+++ b/CCLocation/Inertial/CCInertial.swift
@@ -206,6 +206,7 @@ class CCInertial: NSObject {
             
             guard let tempYaw = findFirstSmallerYaw(yawArray: yawDataBuffer, timeInterval: tempTimeStamp) else {
                 Log.debug("Temp yaw is nil. Steps won't be sent to server")
+                Log.warning("Step discarded")
                 continue
             }
             
@@ -219,6 +220,8 @@ class CCInertial: NSObject {
             
             let stepDate = Date(timeIntervalSince1970: tempTimeStamp)
             let angle = rad2deg(tempYaw.yaw)
+            
+            Log.warning("Step validated")
             self.delegate?.receivedStep(date: stepDate, angle: angle)
         }
     }

--- a/CCLocation/Inertial/CCInertial.swift
+++ b/CCLocation/Inertial/CCInertial.swift
@@ -42,6 +42,7 @@ class CCInertial: NSObject {
         // The 5 seconds time frame is the estimated time (+ margin) for the user to make a choice in granting permission
         DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
             if #available(iOS 11.0, *) {
+                if self.stateStore == nil { return }
                 switch CMMotionActivityManager.authorizationStatus() {
                     case .authorized:  DispatchQueue.main.async {self.stateStore.dispatch(IsMotionAndFitnessEnabledAction(isMotionAndFitnessEnabled: true))}
                     case .restricted, .denied:  DispatchQueue.main.async {self.stateStore.dispatch(IsMotionAndFitnessEnabledAction(isMotionAndFitnessEnabled: false))}

--- a/CCLocation/Inertial/CCInertial.swift
+++ b/CCLocation/Inertial/CCInertial.swift
@@ -130,12 +130,6 @@ class CCInertial: NSObject {
         }
     }
     
-    @objc private func updateDeviceMotionData() {
-        if let data = self.motion.deviceMotion {
-            handleDeviceMotionData(data)
-        }
-    }
-    
     private func handleDeviceMotionData(_ data: CMDeviceMotion) {
         let yawValue = data.attitude.yaw
         let yawData = YawData(yaw: yawValue, date: Date())
@@ -155,7 +149,10 @@ class CCInertial: NSObject {
 
         if self.yawDataBuffer.count >= bufferSize {
             let upperLimit = bufferSize - cutOff - 1
-            self.yawDataBuffer.removeSubrange(0 ... upperLimit)
+            // Check since the yawDataBuffer may change its value meanwhile on another thread
+            if self.yawDataBuffer.count >= upperLimit {
+                self.yawDataBuffer.removeSubrange(0 ... upperLimit)
+            }
         }
     }
     

--- a/CCLocation/LocationManager/CCLocationManager+Bluetooth.swift
+++ b/CCLocation/LocationManager/CCLocationManager+Bluetooth.swift
@@ -229,6 +229,8 @@ extension CCLocationManager: BeaconScannerDelegate {
 extension CCLocationManager {
     
     fileprivate func checkIfWindowSizeAndMaxObservationsAreAvailable(_ isFilterAvailable: inout Bool) {
+        if stateStore == nil { return }
+        
         guard let currentBeaconState = stateStore.state.locationSettingsState.currentLocationState?.currentBeaconState else {
             return
         }

--- a/CCLocation/LocationManager/CCLocationManager+Bluetooth.swift
+++ b/CCLocation/LocationManager/CCLocationManager+Bluetooth.swift
@@ -338,7 +338,10 @@ extension CCLocationManager {
 // CBCentralManagerDelegate
 extension CCLocationManager {
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        DispatchQueue.main.async {self.stateStore.dispatch(BluetoothHardwareChangedAction(bluetoothHardware: central.centralManagerState))}
+        DispatchQueue.main.async {
+            if self.stateStore == nil { return }
+            self.stateStore.dispatch(BluetoothHardwareChangedAction(bluetoothHardware: central.centralManagerState))
+        }
     }
 }
 

--- a/CCLocation/LocationManager/CCLocationManager+StoreSubscriber.swift
+++ b/CCLocation/LocationManager/CCLocationManager+StoreSubscriber.swift
@@ -78,7 +78,10 @@ extension CCLocationManager: StoreSubscriber {
             
             wakeupState = newWakeupNotificationState
             if wakeupState.ccWakeup == CCWakeup.notifyWakeup {
-                DispatchQueue.main.async { self.stateStore.dispatch(NotifyWakeupAction(ccWakeup: CCWakeup.idle)) }
+                DispatchQueue.main.async {
+                    if self.stateStore == nil { return }
+                    self.stateStore.dispatch(NotifyWakeupAction(ccWakeup: CCWakeup.idle))
+                }
             }
         }
     }
@@ -130,7 +133,10 @@ extension CCLocationManager: StoreSubscriber {
         if let offTime = newGEOState.offTime {
             if offTime <= Date() {
                 Log.debug("GeoTimer offTime passed and reset to nil")
-                DispatchQueue.main.async { self.stateStore.dispatch(SetGEOOffTimeEnd(offTimeEnd: nil)) }
+                DispatchQueue.main.async {
+                    if self.stateStore == nil { return }
+                    self.stateStore.dispatch(SetGEOOffTimeEnd(offTimeEnd: nil))
+                }
             }
             
             // If there's no offTime, start the location manager for maxRuntime
@@ -174,7 +180,10 @@ extension CCLocationManager: StoreSubscriber {
         }
       
         if newGEOState.offTime != nil {
-            DispatchQueue.main.async { self.stateStore.dispatch(SetGEOOffTimeEnd(offTimeEnd: nil)) }
+            DispatchQueue.main.async {
+                if self.stateStore == nil { return }
+                self.stateStore.dispatch(SetGEOOffTimeEnd(offTimeEnd: nil))
+            }
         }
     }
     

--- a/CCLocation/LocationManager/CCLocationManager.swift
+++ b/CCLocation/LocationManager/CCLocationManager.swift
@@ -101,8 +101,12 @@ class CCLocationManager: NSObject, CLLocationManagerDelegate, CBCentralManagerDe
         }
         
         // initial dispatch of location state
-        DispatchQueue.main.async {stateStore.dispatch(LocationAuthStatusChangedAction(locationAuthStatus: CLLocationManager.authorizationStatus()))}
-        DispatchQueue.main.async {stateStore.dispatch(IsLocationServicesEnabledAction(isLocationServicesEnabled: CLLocationManager.locationServicesEnabled()))}
+        DispatchQueue.main.async {
+            if self.stateStore != nil {
+                stateStore.dispatch(LocationAuthStatusChangedAction(locationAuthStatus: CLLocationManager.authorizationStatus()))
+                stateStore.dispatch(IsLocationServicesEnabledAction(isLocationServicesEnabled: CLLocationManager.locationServicesEnabled()))
+            }
+        }
         
         openIBeaconDatabase()
         createIBeaconTable()
@@ -143,9 +147,15 @@ class CCLocationManager: NSObject, CLLocationManagerDelegate, CBCentralManagerDe
             if minOffTime > 0 {
                 let offTimeEnd = Date().addingTimeInterval(TimeInterval(minOffTime / 1000))
                 
-                DispatchQueue.main.async {self.stateStore.dispatch(SetGEOOffTimeEnd(offTimeEnd: offTimeEnd))}
+                DispatchQueue.main.async {
+                    if self.stateStore == nil { return }
+                    self.stateStore.dispatch(SetGEOOffTimeEnd(offTimeEnd: offTimeEnd))
+                }
             } else {
-                DispatchQueue.main.async {self.stateStore.dispatch(SetGEOOffTimeEnd(offTimeEnd: nil))}
+                DispatchQueue.main.async {
+                    if self.stateStore == nil { return }
+                    self.stateStore.dispatch(SetGEOOffTimeEnd(offTimeEnd: nil))
+                }
             }
         }
     }
@@ -354,8 +364,11 @@ extension CCLocationManager {
     }
     
     private func triggerWakeUpAction() {
-        DispatchQueue.main.async {self.stateStore.dispatch(NotifyWakeupAction(ccWakeup: CCWakeup.idle))}
-        DispatchQueue.main.async {self.stateStore.dispatch(NotifyWakeupAction(ccWakeup: CCWakeup.notifyWakeup))}
+        DispatchQueue.main.async {
+            if self.stateStore == nil { return }
+            self.stateStore.dispatch(NotifyWakeupAction(ccWakeup: CCWakeup.idle))
+            self.stateStore.dispatch(NotifyWakeupAction(ccWakeup: CCWakeup.notifyWakeup))
+        }
     }
     
     public func locationManager(_ manager: CLLocationManager, didDetermineState state: CLRegionState, for region: CLRegion) {
@@ -396,8 +409,12 @@ extension CCLocationManager {
     public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         Log.debug("Changed authorization status")
         
-        DispatchQueue.main.async {self.stateStore.dispatch(LocationAuthStatusChangedAction(locationAuthStatus: status))}
-        DispatchQueue.main.async {self.stateStore.dispatch(IsLocationServicesEnabledAction(isLocationServicesEnabled: CLLocationManager.locationServicesEnabled()))}
+        DispatchQueue.main.async {
+            if self.stateStore != nil {
+                self.stateStore.dispatch(LocationAuthStatusChangedAction(locationAuthStatus: status))
+                self.stateStore.dispatch(IsLocationServicesEnabledAction(isLocationServicesEnabled: CLLocationManager.locationServicesEnabled()))
+            }
+        }
         
         switch (status) {
         case .notDetermined:

--- a/CCLocation/RequestMessaging/CCRequestMessaging+AnalyzeMessages.swift
+++ b/CCLocation/RequestMessaging/CCRequestMessaging+AnalyzeMessages.swift
@@ -366,7 +366,10 @@ extension CCRequestMessaging {
                 if let batteryLevel = stateStore.state.batteryLevelState.batteryLevel {
                     batteryMessage.battery = batteryLevel
                     newBatteryMessage = batteryMessage
-                    DispatchQueue.main.async {self.stateStore.dispatch(BatteryLevelReportedAction())}
+                    DispatchQueue.main.async {
+                        if self.stateStore == nil { return }
+                        self.stateStore.dispatch(BatteryLevelReportedAction())
+                    }
                 }
             }
         }

--- a/CCLocation/RequestMessaging/CCRequestMessaging+ProcessiOSSettings.swift
+++ b/CCLocation/RequestMessaging/CCRequestMessaging+ProcessiOSSettings.swift
@@ -16,8 +16,6 @@ import CoreBluetooth
 extension CCRequestMessaging {
     
     func processIosSettings (serverMessage: Messaging_ServerMessage, store: Store<LibraryState>) {
-        Log.debug("Got iOS settings message")
-        
         // When Missing Settings
         
         if serverMessage.hasIosSettings && !serverMessage.iosSettings.hasGeoSettings {

--- a/CCLocation/RequestMessaging/CCRequestMessaging+SendMessages.swift
+++ b/CCLocation/RequestMessaging/CCRequestMessaging+SendMessages.swift
@@ -26,6 +26,7 @@ extension CCRequestMessaging {
     }
     
     private func sendAllMessagesFromDatabase() {
+        Log.warning("Try to send multiple messages")
         DispatchQueue.global(qos: .default).async { [weak self] in
             let maxMessagesToReturn = 100
             var connectionState = self?.stateStore.state.ccRequestMessagingState.webSocketState?.connectionState
@@ -69,6 +70,7 @@ extension CCRequestMessaging {
                 
                 if let data = try? compiledClientMessage.serializedData(), data.count > 0 {
                     self?.setupSentTime(forMessage: &compiledClientMessage)
+                    Log.warning("Successfully sent multiple messages")
                     self?.sendMessageThroughSocket(compiledClientMessage)
                 }
             }
@@ -76,6 +78,7 @@ extension CCRequestMessaging {
     }
     
     func sendSingleMessage(_ message: Data) {
+        Log.warning("Try to send single message")
         DispatchQueue.global(qos: .default).async { [weak self] in
             var (_,
                  compiledClientMessage,
@@ -87,6 +90,7 @@ extension CCRequestMessaging {
         
             if let data = try? compiledClientMessage.serializedData(), data.count > 0 {
                 self?.setupSentTime(forMessage: &compiledClientMessage)
+                Log.warning("Successfully sent single message")
                 self?.sendMessageThroughSocket(compiledClientMessage)
             }
         }

--- a/CCLocation/RequestMessaging/CCRequestMessaging+SendMessages.swift
+++ b/CCLocation/RequestMessaging/CCRequestMessaging+SendMessages.swift
@@ -26,7 +26,6 @@ extension CCRequestMessaging {
     }
     
     private func sendAllMessagesFromDatabase() {
-        Log.warning("Try to send multiple messages")
         DispatchQueue.global(qos: .default).async { [weak self] in
             let maxMessagesToReturn = 100
             var connectionState = self?.stateStore.state.ccRequestMessagingState.webSocketState?.connectionState
@@ -70,7 +69,6 @@ extension CCRequestMessaging {
                 
                 if let data = try? compiledClientMessage.serializedData(), data.count > 0 {
                     self?.setupSentTime(forMessage: &compiledClientMessage)
-                    Log.warning("Successfully sent multiple messages")
                     self?.sendMessageThroughSocket(compiledClientMessage)
                 }
             }
@@ -78,7 +76,6 @@ extension CCRequestMessaging {
     }
     
     func sendSingleMessage(_ message: Data) {
-        Log.warning("Try to send single message")
         DispatchQueue.global(qos: .default).async { [weak self] in
             var (_,
                  compiledClientMessage,
@@ -90,7 +87,6 @@ extension CCRequestMessaging {
         
             if let data = try? compiledClientMessage.serializedData(), data.count > 0 {
                 self?.setupSentTime(forMessage: &compiledClientMessage)
-                Log.warning("Successfully sent single message")
                 self?.sendMessageThroughSocket(compiledClientMessage)
             }
         }

--- a/CCLocation/RequestMessaging/CCRequestMessaging+SendMessages.swift
+++ b/CCLocation/RequestMessaging/CCRequestMessaging+SendMessages.swift
@@ -26,7 +26,7 @@ extension CCRequestMessaging {
     }
     
     private func sendAllMessagesFromDatabase() {
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        DispatchQueue.global(qos: .default).async { [weak self] in
             let maxMessagesToReturn = 100
             var connectionState = self?.stateStore.state.ccRequestMessagingState.webSocketState?.connectionState
             
@@ -76,7 +76,7 @@ extension CCRequestMessaging {
     }
     
     func sendSingleMessage(_ message: Data) {
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        DispatchQueue.global(qos: .default).async { [weak self] in
             var (_,
                  compiledClientMessage,
                  backToQueueMessage) = self?.handleMessageType(message: message) ?? (0,

--- a/CCLocation/RequestMessaging/CCRequestMessaging+SendMessages.swift
+++ b/CCLocation/RequestMessaging/CCRequestMessaging+SendMessages.swift
@@ -26,7 +26,7 @@ extension CCRequestMessaging {
     }
     
     private func sendAllMessagesFromDatabase() {
-        DispatchQueue.global(qos: .default).async { [weak self] in
+        DispatchQueue.global(qos: .utility).async { [weak self] in
             let maxMessagesToReturn = 100
             var connectionState = self?.stateStore.state.ccRequestMessagingState.webSocketState?.connectionState
             
@@ -76,7 +76,7 @@ extension CCRequestMessaging {
     }
     
     func sendSingleMessage(_ message: Data) {
-        DispatchQueue.global(qos: .default).async { [weak self] in
+        DispatchQueue.global(qos: .utility).async { [weak self] in
             var (_,
                  compiledClientMessage,
                  backToQueueMessage) = self?.handleMessageType(message: message) ?? (0,

--- a/CCLocation/RequestMessaging/CCRequestMessaging+SystemNotification.swift
+++ b/CCLocation/RequestMessaging/CCRequestMessaging+SystemNotification.swift
@@ -19,7 +19,10 @@ extension CCRequestMessaging {
     @objc func applicationDidEnterBackground() {
         Log.debug("[APP STATE] applicationDidEnterBackground")
         
-        DispatchQueue.main.async {self.stateStore.dispatch(LifeCycleAction(lifecycleState: LifeCycle.background))}
+        DispatchQueue.main.async {
+            if self.stateStore == nil { return }
+            self.stateStore.dispatch(LifeCycleAction(lifecycleState: LifeCycle.background))
+        }
     }
     
     @objc func applicationWillEnterForeground() {
@@ -29,7 +32,10 @@ extension CCRequestMessaging {
     @objc func applicationDidBecomeActive() {
         Log.debug("[APP STATE] applicationDidBecomeActive")
         
-        DispatchQueue.main.async {self.stateStore.dispatch(LifeCycleAction(lifecycleState: LifeCycle.foreground))}
+        DispatchQueue.main.async {
+            if self.stateStore == nil { return }
+            self.stateStore.dispatch(LifeCycleAction(lifecycleState: LifeCycle.foreground))
+        }
     }
     
     @objc func applicationWillTerminate() {
@@ -83,16 +89,18 @@ extension CCRequestMessaging {
     @objc func batteryLevelDidChange(notification: Notification) {
         let batteryLevel = UIDevice.current.batteryLevel
         
-        DispatchQueue.main.async {self.stateStore.dispatch(BatteryLevelChangedAction(batteryLevel: UInt32(batteryLevel * 100)))}
+        DispatchQueue.main.async {
+            if self.stateStore == nil { return }
+            self.stateStore.dispatch(BatteryLevelChangedAction(batteryLevel: UInt32(batteryLevel * 100)))
+        }
     }
     
     @objc func batteryStateDidChange(notification: Notification) {
         let batteryState = UIDevice.current.batteryState
         
         DispatchQueue.main.async {
-            if self.stateStore != nil {
-                self.stateStore.dispatch(BatteryStateChangedAction(batteryState: batteryState))
-            }
+            if self.stateStore == nil { return }
+            self.stateStore.dispatch(BatteryStateChangedAction(batteryState: batteryState))
         }
     }
         
@@ -100,7 +108,10 @@ extension CCRequestMessaging {
         if #available(iOS 9.0, *) {
             let isLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
             
-            DispatchQueue.main.async {self.stateStore.dispatch(IsLowPowerModeEnabledAction(isLowPowerModeEnabled: isLowPowerMode))}
+            DispatchQueue.main.async {
+                if self.stateStore == nil { return }
+                self.stateStore.dispatch(IsLowPowerModeEnabledAction(isLowPowerModeEnabled: isLowPowerMode))
+            }
         }
     }
 }

--- a/CCLocation/RequestMessaging/CCRequestMessaging.swift
+++ b/CCLocation/RequestMessaging/CCRequestMessaging.swift
@@ -156,14 +156,18 @@ class CCRequestMessaging: NSObject {
     // MARK: - STATE HANDLING FUNCTIONS
     
     public func webSocketDidOpen() {
-        if stateStore != nil {
-            DispatchQueue.main.async {self.stateStore.dispatch(WebSocketAction(connectionState: ConnectionState.online))}
+        DispatchQueue.main.async {
+            if self.stateStore != nil {
+                self.stateStore.dispatch(WebSocketAction(connectionState: ConnectionState.online))
+            }
         }
     }
     
     public func webSocketDidClose() {
-        if stateStore != nil {
-            DispatchQueue.main.async {self.stateStore.dispatch(WebSocketAction(connectionState: ConnectionState.offline))}
+        DispatchQueue.main.async {
+            if self.stateStore != nil {
+                self.stateStore.dispatch(WebSocketAction(connectionState: ConnectionState.offline))
+            }
         }
     }
     

--- a/CCLocation/RequestMessaging/CCRequestMessaging.swift
+++ b/CCLocation/RequestMessaging/CCRequestMessaging.swift
@@ -157,17 +157,15 @@ class CCRequestMessaging: NSObject {
     
     public func webSocketDidOpen() {
         DispatchQueue.main.async {
-            if self.stateStore != nil {
-                self.stateStore.dispatch(WebSocketAction(connectionState: ConnectionState.online))
-            }
+            if self.stateStore == nil { return }
+            self.stateStore.dispatch(WebSocketAction(connectionState: ConnectionState.online))
         }
     }
     
     public func webSocketDidClose() {
         DispatchQueue.main.async {
-            if self.stateStore != nil {
-                self.stateStore.dispatch(WebSocketAction(connectionState: ConnectionState.offline))
-            }
+            if self.stateStore == nil { return }
+            self.stateStore.dispatch(WebSocketAction(connectionState: ConnectionState.offline))
         }
     }
     
@@ -241,7 +239,10 @@ class CCRequestMessaging: NSObject {
         sendQueuedClientMessagesTimerFired()
         
         // now we simply resume the normal timer
-        DispatchQueue.main.async {self.stateStore.dispatch(ScheduleSilencePeriodTimerAction())}
+        DispatchQueue.main.async {
+            if self.stateStore == nil { return }
+            self.stateStore.dispatch(ScheduleSilencePeriodTimerAction())
+        }
     }
     
     func stop() {
@@ -279,6 +280,7 @@ extension CCRequestMessaging: TimeHandlingDelegate {
             """)
         
         DispatchQueue.main.async {
+            if self.stateStore == nil { return }
             self.stateStore.dispatch(NewTruetimeReceivedAction(lastTrueTime: trueTime,
                                                                bootTimeIntervalAtLastTrueTime: timeIntervalSinceBootTime,
                                                                systemTimeAtLastTrueTime: systemTime,
@@ -290,7 +292,10 @@ extension CCRequestMessaging: TimeHandlingDelegate {
         }
         
         if radioSilenceTimerState.timer == .stopped && radioSilenceTimerState.startTimeInterval != nil {
-            DispatchQueue.main.async {self.stateStore.dispatch(ScheduleSilencePeriodTimerAction())}
+            DispatchQueue.main.async {
+                if self.stateStore == nil { return }
+                self.stateStore.dispatch(ScheduleSilencePeriodTimerAction())
+            }
         }
     }
 }


### PR DESCRIPTION
Background steps bug fixed (DeviceMotion data moved on its own operation queue)
Radio silence BUG fixed (it was sending data only in real-time or > 16 min)
Sending messages moved from .background. to .utility (suits better for networking, fetching and long-running tasks)
Added proof for crashing in case state store is nil
Assured that the library restarts properly in case of background refresh or SPN
